### PR TITLE
Add package RSS and Atom feeds

### DIFF
--- a/app/controllers/packages_controller.rb
+++ b/app/controllers/packages_controller.rb
@@ -29,6 +29,12 @@ class PackagesController < ApplicationController
     end
 
     fresh_when(@packages, public: true)
+
+    respond_to do |format|
+      format.html
+      format.rss
+      format.atom
+    end
   end
 
   def show

--- a/app/views/packages/index.atom.builder
+++ b/app/views/packages/index.atom.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.feed xmlns: 'http://www.w3.org/2005/Atom' do
+  xml.title 'Docker Images'
+  xml.subtitle 'Latest Docker images indexed by ecosyste.ms'
+  xml.id packages_url
+  xml.link href: packages_url
+  xml.link href: packages_url(format: :atom), rel: 'self', type: 'application/atom+xml'
+  xml.updated((@packages.first&.last_synced_at || Time.current).iso8601)
+
+  @packages.each do |package|
+    xml.entry do
+      xml.title package.name
+      xml.id package_url(package)
+      xml.link href: package_url(package)
+      xml.updated((package.last_synced_at || package.updated_at || Time.current).iso8601)
+      xml.summary package.description if package.description.present?
+    end
+  end
+end

--- a/app/views/packages/index.html.erb
+++ b/app/views/packages/index.html.erb
@@ -1,3 +1,8 @@
+<% content_for :head do %>
+  <%= auto_discovery_link_tag(:rss, packages_url(format: :rss), title: "Docker Images RSS") %>
+  <%= auto_discovery_link_tag(:atom, packages_url(format: :atom), title: "Docker Images Atom") %>
+<% end %>
+
 <% @meta_title = "Docker Container Analysis" %>
 <% @meta_description = "Discover dependencies, packages, and Linux distributions extracted from hundreds of thousands of public Docker images. Track usage patterns across ecosystems and explore the open source software powering containerized applications." %>
 

--- a/app/views/packages/index.rss.builder
+++ b/app/views/packages/index.rss.builder
@@ -1,0 +1,19 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.rss version: '2.0' do
+  xml.channel do
+    xml.title 'Docker Images'
+    xml.description 'Latest Docker images indexed by ecosyste.ms'
+    xml.link packages_url
+    xml.language 'en'
+
+    @packages.each do |package|
+      xml.item do
+        xml.title package.name
+        xml.description package.description if package.description.present?
+        xml.link package_url(package)
+        xml.guid package_url(package), isPermaLink: true
+        xml.pubDate package.last_synced_at.rfc2822 if package.last_synced_at.present?
+      end
+    end
+  end
+end

--- a/test/controllers/packages_controller_test.rb
+++ b/test/controllers/packages_controller_test.rb
@@ -17,6 +17,33 @@ class PackagesControllerTest < ActionDispatch::IntegrationTest
       assert_response :success
     end
     
+
+    should "provide RSS and Atom auto discovery links" do
+      get packages_path
+
+      assert_response :success
+      assert_select 'link[rel="alternate"][type="application/rss+xml"][href=?]', packages_url(format: :rss)
+      assert_select 'link[rel="alternate"][type="application/atom+xml"][href=?]', packages_url(format: :atom)
+    end
+
+    should "render RSS feed" do
+      get packages_path(format: :rss)
+
+      assert_response :success
+      assert_equal 'application/rss+xml', response.media_type
+      assert_includes response.body, '<rss'
+      assert_includes response.body, @package.name
+    end
+
+    should "render Atom feed" do
+      get packages_path(format: :atom)
+
+      assert_response :success
+      assert_equal 'application/atom+xml', response.media_type
+      assert_includes response.body, '<feed'
+      assert_includes response.body, @package.name
+    end
+
     should "show packages with SBOM by default" do
       get packages_path
       


### PR DESCRIPTION
Refs #22

## Summary
- adds RSS and Atom feed responses for the Docker images/packages list endpoint
- adds feed auto-discovery links in the HTML head for the packages index
- covers the HTML discovery links and feed responses in controller tests

## Validation
- `ruby -c app/controllers/packages_controller.rb`
- `ruby -c app/views/packages/index.rss.builder`
- `ruby -c app/views/packages/index.atom.builder`
- `ruby -c test/controllers/packages_controller_test.rb`
- `git diff --check`

Full controller test execution is locally blocked because the lockfile requires Bundler 4.0.10 and this system Ruby cannot activate it.